### PR TITLE
Update pin.py

### DIFF
--- a/src/adafruit_blinka/microcontroller/am335x/pin.py
+++ b/src/adafruit_blinka/microcontroller/am335x/pin.py
@@ -330,8 +330,8 @@ UART5_CTSn = Pin("UART5_CTSn")
 
 # ordered as spiId, sckId, mosiId, misoId
 spiPorts = (
-    (1, SPI0_SCLK, SPI0_D1, SPI0_D0),
-    (2, SPI1_SCLK, SPI1_D1, SPI1_D0),
+    (0, SPI0_SCLK, SPI0_D1, SPI0_D0),
+    (1, SPI1_SCLK, SPI1_D1, SPI1_D0),
 )
 
 # ordered as uartId, txId, rxId


### PR DESCRIPTION
On beaglebone black, the spi devices are spidev0.0, spidev0.1, spidev1.0, spidev1.1 and the existing code tries to open up spidev2.0 when using SPI1. Renumbering fixes this.